### PR TITLE
Fix bug in install.sh where PyTorch always installed with CUDA version 10.1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,15 @@ conda activate gnn-comparison
 pip install -r requirements.txt
 
 # install pytorch
-conda install pytorch==${PYTORCH_VERSION} -c pytorch -y
+if [[ "$CUDA_VERSION" == "cpu" ]]; then 
+  conda install pytorch==${PYTORCH_VERSION} cpuonly -c pytorch -y
+elif [[ "$CUDA_VERSION" == 'cu92' ]]; then
+  conda install pytorch==${PYTORCH_VERSION} cudatoolkit=9.2 -c pytorch -y
+elif [[ "$CUDA_VERSION" == 'cu100' ]]; then
+  conda install pytorch==${PYTORCH_VERSION} cudatoolkit=10.0 -c pytorch -y
+elif [[ "$CUDA_VERSION" == 'cu101' ]]; then
+  conda install pytorch==${PYTORCH_VERSION} cudatoolkit=10.1 -c pytorch -y
+fi
 
 # install torch-geometric dependencies
 pip install torch-scatter==latest+${CUDA_VERSION} -f https://pytorch-geometric.com/whl/torch-${PYTORCH_VERSION}.html


### PR DESCRIPTION
The current install script does not specify which PyTorch version to install. By default it would install PyTorch with CUDA=10.1. If e.g. "cpu" was passed to the install script it would therefore install incompatible PyTorch and PyTorch Geometric libraries.

I ran the instructions (PrepareDatasets & LaunchExperiment) once using a cpu to test. I did not test installing PyTorch with other CUDA versions.